### PR TITLE
Enable DUA type switch for the NLP data set

### DIFF
--- a/app/authorization/fixtures/authorization.json
+++ b/app/authorization/fixtures/authorization.json
@@ -53,10 +53,20 @@
     "model": "authorization.DataUseAgreement",
     "pk": 2,
     "fields": {
-      "name": "NLP",
+      "name": "Academic",
       "project": 4,
       "agreement_text": "",
-      "agreement_form_file": "nlp.html" 
+      "agreement_form_file": "nlp-academic.html" 
+    }
+  },
+  {
+    "model": "authorization.DataUseAgreement",
+    "pk": 3,
+    "fields": {
+      "name": "Commercial",
+      "project": 4,
+      "agreement_text": "",
+      "agreement_form_file": "nlp-commercial.html" 
     }
   }
 ]

--- a/app/authorization/serializers.py
+++ b/app/authorization/serializers.py
@@ -39,8 +39,6 @@ class DataUseAgreementSerializer(serializers.ModelSerializer):
         if dua.agreement_form_file != "":
             form_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + '/templates/duaforms/' + dua.agreement_form_file
             return open(form_path, 'r').read()
-        else:
-            return dua.agreement_text
 
 
 class PermissionRequestSerializer(serializers.ModelSerializer):

--- a/app/templates/duaforms/nlp-academic.html
+++ b/app/templates/duaforms/nlp-academic.html
@@ -1,0 +1,86 @@
+<strong>Partners HealthCare</strong><br>
+<strong>i2b2 National Center for Biomedical Computing</strong><br>
+<br>
+<strong>DATA USE AND CONFIDENTIALITY AGREEMENT</strong><br>
+<strong>for Academic Organizations for access to data from the Challenges in Natural Language Processing for Clinical Data Shared Task Competitions</strong><br>
+<br>
+This Data Use and Confidentiality Agreement (the "Agreement") is made as of the <input type="text" class="" name="day" size="4" maxlength="2" placeholder="day"/> day of <input type="text" class="" name="month" placeholder="month"/>, <input type="text" class="" name="year" size="4" maxlength="4" placeholder="year"/> by and between Partners HealthCare System, Inc., through its i2b2 National Center for Biomedical Computing, and on behalf of itself and its affiliates (collectively, "Partners") and <input type="text" class="" name="data_user" size="35" placeholder="name"/> ("Data User").<br>
+<br>
+WHEREAS, the Partners i2b2 National Center for Biomedical Computing operates an annual Challenges in Natural Language Processing for Clinical Data Shared Task Competition (the "Competition"); and<br>
+<br>
+WHEREAS, Partners controls certain patient-level data in the form of patient discharge summaries from its clinical information systems, which data have been De-Identified within the meaning of the Health Insurance Portability and Accountability Act of 1996 privacy regulations ("HIPAA") and previously utilized and annotated by participants in the Competition (the "Data"); and<br>
+<br>
+WHEREAS, Partners has an interest in supporting the research and development of Natural Language Processing tools and analytics that may advance the meaningful use of electronic health records; and<br>
+<br>
+WHEREAS, to the extent permitted by its Institutional Review Board and institutional policies, Partners now wishes to make the Data, in the form of one or more "Datasets," available to Data User for the purpose of conducting such independent research and development (the "Purpose"), and Data User wishes to receive the Datasets for this Purpose under the terms and conditions of access set forth herein;<br>
+<br>
+NOW, THEREFORE, in consideration of the mutual promises and covenants set forth below, the parties hereby agree as follows:<br>
+<br>
+1. Data User is either (check one):<br>
+<br>
+<input type="checkbox" name="individual_checkbox" class=""/> An individual, requesting Data/Datasets under this Agreement on behalf of himself/herself as follows:<br><br>
+Name: <input type="text" class="form-control" name="individual_name"/><br>
+Professional Title: <input type="text" class="form-control" name="individual_professional_title"/><br>
+Address: <input type="text" class="form-control" name="individual_address"/><br>
+Telephone: <input type="text" class="form-control" name="individual_telephone"/><br>
+Fax: <input type="text" class="form-control" name="individual_fax"/><br>
+E-mail: <input type="text" class="form-control" name="individual_email"/><br><br>
+OR<br><br>
+<input type="checkbox" name="institution_checkbox" class=""/> An organization / institution, requesting Data/Datasets under this Agreement on behalf of itself and its employees with a principal place of business and primary business contact as follows:<br><br>
+Principal Place of Business: <input type="text" class="form-control" name="institution_place_of_business"/><br>
+Contact Name/Title: <input type="text" class="form-control" name="instution_contact_name"/><br>
+Telephone: <input type="text" class="form-control" name="institution_telephone"/><br>
+Fax: <input type="text" class="form-control" name="institution_fax"/><br>
+E-mail: <input type="text" class="form-control" name="instituion_email"/><br>
+<br>
+2. Data User will describe to Partners via the electronic registration process for Data access at www.i2b2.org the specific natural language processing research and development use for the Data / Datasets proposed by Data User (the "Specific Purpose"). For avoidance of doubt, permissible uses may include use of the Data / Datasets for evaluation and testing of a natural language processing tool or technology but will not extend to proposals that include or incorporate the Data / Datasets into such product. Partners will provide the Data / Datasets requested by the Data User upon Partners' approval, in its sole discretion, of the Specific Purpose.<br>
+<br>
+3. Any Data/Datasets provided to Data User under this Agreement will be De-Identified within the meaning of HIPAA. Data User agrees that Data User will not attempt to identify or re-identify any individual patient or group of patients from the Data / Datasets.<br>
+<br>
+4. Data User agrees that Data User will use the Data / Datasets solely for the Specific Purpose and for no other purpose.<br>
+<br>
+5. Data User understands and agrees that the Data / Datasets are proprietary and confidential to Partners and agrees that Data User will not disclose, disseminate, or otherwise share the Data / Datasets to or with any other person or entity, including any subcontractor, for any purpose, without the prior written consent of Partners. To the extent Partners agrees in writing to permit such further access, the Data User will ensure that such further recipient of the Data / Datasets agrees in writing to all of the same restrictions, conditions and obligations that apply to Data User with respect to the Data / Datasets, and will make Partners a third-party beneficiary of such agreement.<br>
+<br>
+Persons/Entities on Registrant's Research team<br>
+1) <input type="text" class="" name="research_team_1_name" placeholder="name"/> <input type="text" class="" name="research_team_1_signature" placeholder="signature"/> <input type="text" class="" name="research_team_1_email" placeholder="email"/><br>
+2) <input type="text" class="" name="research_team_2_name" placeholder="name"/> <input type="text" class="" name="research_team_2_signature" placeholder="signature"/> <input type="text" class="" name="research_team_2_email" placeholder="email"/><br>
+3) <input type="text" class="" name="research_team_3_name" placeholder="name"/> <input type="text" class="" name="research_team_3_signature" placeholder="signature"/> <input type="text" class="" name="research_team_3_email" placeholder="email"/><br>
+Registrant shall be responsible for compliance by these persons/entities with the terms of this Agreement and any breach thereof.<br>
+<br>
+6. If the Data User determines that it is Required by Law (as that term is defined in the HIPAA privacy regulations) to use or disclose the Data / Datasets other than as provided for in this Agreement, Data User shall provide prompt written notice of such determination to Partners so that Partners may have an opportunity to take measures to protect the Data / Datasets as appropriate.<br>
+<br>
+7. Data User will use appropriate safeguards to prevent use or disclosure of the Data / Datasets other than as provided for by this Agreement, and Data User will report immediately to Partners in writing any use or disclosure not provided for by this Agreement of which it becomes aware. The Data User acknowledges that any use or disclosure of the Data / Datasets that is inconsistent with the terms of this Agreement may cause irreparable injury to Partners and agrees that Partners will be entitled to seek injunctive relief with respect to such use and/or disclosure, in addition to seeking any other remedy available at law or in equity.<br>
+<br>
+8. All Data / Datasets disclosed pursuant to this Agreement, including without limitation all written and tangible forms thereof, shall be and remain the property of Partners and Partners shall at all times retain all rights, title and interest in and to the Data / Datasets. Upon the expiration or earlier termination of this Agreement as provided in Section 12 below, the Data User shall cease using the Data / Datasets and shall destroy (or return if so requested by Partners) all of the Data / Datasets received in tangible form, including notes, reports, and other information to the extent it contains the Data / Datasets, and shall keep no copies, except to the extent specifically Required by Law(s) made known to Partners by the Data User.<br>
+<br>
+9. THE DATA / DATASETS ARE PROVIDED "AS IS." PARTNERS MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, CONCERNING THE DATA OR DATASETS OR THE RIGHTS GRANTED HEREIN, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, AND THE ABSENCE OF LATENT OR OTHER DEFECTS, WHETHER OR NOT DISCOVERABLE, AND HEREBY DISCLAIMS THE SAME.<br>
+<br>
+10. IN NO EVENT SHALL PARTNERS OR ANY OF PARTNERS' RESPECTIVE TRUSTEES, DIRECTORS, OFFICERS, MEDICAL OR PROFESSIONAL STAFF, EMPLOYEES AND AGENTS BE LIABLE TO THE DATA USER FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES OF ANY KIND ARISING IN ANY WAY OUT OF THIS AGREEMENT OR RIGHTS GRANTED HEREIN, HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, INCLUDING WITHOUT LIMITATION, ECONOMIC DAMAGES OR INJURY TO PROPERTY OR LOST PROFITS, REGARDLESS OF WHETHER PARTNERS SHALL BE ADVISED, SHALL HAVE OTHER REASON TO KNOW, OR IN FACT SHALL KNOW OF THE POSSIBILITY OF THE FOREGOING.<br>
+<br>
+11. Data User agrees not to use the name or logo of Partners or any of its affiliates or any of their respective trustees, directors, officers, staff members, employees, students or agents for any purpose without Partners' prior written approval; provided, however, that Data User will acknowledge Partners as the source of the Data / Datasets in any publication or presentation arising from the Specific Purpose.<br>
+<br>
+12. This Agreement shall become effective upon Partners' release of Data / Datasets to Data User and shall expire upon Data User's completion of the Specific Purpose. Partners may terminate the Agreement and Data User's access to Data / Datasets hereunder at any prior time and for any reason upon written notice to the Data User.<br>
+<br>
+13. To the extent Data User is permitted under the terms of this Agreement to retain any portion of the Data / Dataset, or any copies thereof, upon the expiration or termination of the Agreement, the Data User's obligations under the Agreement with respect to such Data / Datasets shall survive such expiration or termination for as long as Data User retains the Data / Datasets.<br>
+<br>
+14. This Agreement may be modified or amended only in a writing signed by duly authorized representatives of both the Data User (where Data User is an organization) and Partners. This Agreement shall be governed by and construed in accordance with the laws of the Commonwealth of Massachusetts. Any claim or action brought under this Agreement shall be brought in the federal or state courts of Massachusetts.<br>
+<br>
+15. All notices required by this Agreement shall be provided to the signatory for each party at the address identified below.<br>
+<br>
+16. Sections 3 through 11 and Sections 13, 14, and 15 of this Agreement shall survive its expiration or termination.<br>
+<br>
+Agreed to by:<br>
+<br>
+PARTNERS<br>
+<br>
+Name:<input type="text" class="form-control" name="partners_name"/><br>
+Title: <input type="text" class="form-control" name="partners_title"/><br>
+Address: <input type="text" class="form-control" name="partners_address"/><br>
+Date: <input type="text" class="form-control" name="partners_date"><br><br>
+DATA USER<br>
+<br>
+Signature of Data User (of Data User's Duly Authorized Representative, if an organization)<input type="text" class="form-control" name="data_user_signature"/><br>
+ame:<input type="text" class="form-control" name="data_user_name"/><br>
+Title: <input type="text" class="form-control" name="data_user_title"/><br>
+Address: <input type="text" class="form-control" name="data_user_address"/><br>
+Date: <input type="text" class="form-control" name="data_user_date"/><br>

--- a/app/templates/duaforms/nlp-commercial.html
+++ b/app/templates/duaforms/nlp-commercial.html
@@ -2,7 +2,7 @@
 <strong>i2b2 National Center for Biomedical Computing</strong><br>
 <br>
 <strong>DATA USE AND CONFIDENTIALITY AGREEMENT</strong><br>
-<strong>for Academic Organizations for access to data from the Challenges in Natural Language Processing for Clinical Data Shared Task Competitions</strong><br>
+<strong>for Commercial Organizations for access to data from the Challenges in Natural Language Processing for Clinical Data Shared Task Competitions</strong><br>
 <br>
 This Data Use and Confidentiality Agreement (the "Agreement") is made as of the <input type="text" class="" name="day" size="4" maxlength="2" placeholder="day"/> day of <input type="text" class="" name="month" placeholder="month"/>, <input type="text" class="" name="year" size="4" maxlength="4" placeholder="year"/> by and between Partners HealthCare System, Inc., through its i2b2 National Center for Biomedical Computing, and on behalf of itself and its affiliates (collectively, "Partners") and <input type="text" class="" name="data_user" size="35" placeholder="name"/> ("Data User").<br>
 <br>
@@ -41,33 +41,31 @@ E-mail: <input type="text" class="form-control" name="instituion_email"/><br>
 <br>
 5. Data User understands and agrees that the Data / Datasets are proprietary and confidential to Partners and agrees that Data User will not disclose, disseminate, or otherwise share the Data / Datasets to or with any other person or entity, including any subcontractor, for any purpose, without the prior written consent of Partners. To the extent Partners agrees in writing to permit such further access, the Data User will ensure that such further recipient of the Data / Datasets agrees in writing to all of the same restrictions, conditions and obligations that apply to Data User with respect to the Data / Datasets, and will make Partners a third-party beneficiary of such agreement.<br>
 <br>
-Persons/Entities on Registrant's Research team<br>
-1) <input type="text" class="" name="research_team_1_name" placeholder="name"/> <input type="text" class="" name="research_team_1_signature" placeholder="signature"/> <input type="text" class="" name="research_team_1_email" placeholder="email"/><br>
-2) <input type="text" class="" name="research_team_2_name" placeholder="name"/> <input type="text" class="" name="research_team_2_signature" placeholder="signature"/> <input type="text" class="" name="research_team_2_email" placeholder="email"/><br>
-3) <input type="text" class="" name="research_team_3_name" placeholder="name"/> <input type="text" class="" name="research_team_3_signature" placeholder="signature"/> <input type="text" class="" name="research_team_3_email" placeholder="email"/><br>
-Registrant shall be responsible for compliance by these persons/entities with the terms of this Agreement and any breach thereof.<br>
-<br>
 6. If the Data User determines that it is Required by Law (as that term is defined in the HIPAA privacy regulations) to use or disclose the Data / Datasets other than as provided for in this Agreement, Data User shall provide prompt written notice of such determination to Partners so that Partners may have an opportunity to take measures to protect the Data / Datasets as appropriate.<br>
 <br>
 7. Data User will use appropriate safeguards to prevent use or disclosure of the Data / Datasets other than as provided for by this Agreement, and Data User will report immediately to Partners in writing any use or disclosure not provided for by this Agreement of which it becomes aware. The Data User acknowledges that any use or disclosure of the Data / Datasets that is inconsistent with the terms of this Agreement may cause irreparable injury to Partners and agrees that Partners will be entitled to seek injunctive relief with respect to such use and/or disclosure, in addition to seeking any other remedy available at law or in equity.<br>
 <br>
-8. All Data / Datasets disclosed pursuant to this Agreement, including without limitation all written and tangible forms thereof, shall be and remain the property of Partners and Partners shall at all times retain all rights, title and interest in and to the Data / Datasets. Upon the expiration or earlier termination of this Agreement as provided in Section 12 below, the Data User shall cease using the Data / Datasets and shall destroy (or return if so requested by Partners) all of the Data / Datasets received in tangible form, including notes, reports, and other information to the extent it contains the Data / Datasets, and shall keep no copies, except to the extent specifically Required by Law(s) made known to Partners by the Data User.<br>
+8. All Data / Datasets disclosed pursuant to this Agreement, including without limitation all written and tangible forms thereof, shall be and remain the property of Partners and Partners shall at all times retain all rights, title and interest in and to the Data / Datasets. Upon the expiration or earlier termination of this Agreement as provided in Section 14 below, the Data User shall cease using the Data / Datasets and shall destroy (or return if so requested by Partners) all of the Data / Datasets received in tangible form, including notes, reports, and other information to the extent it contains the Data / Datasets, and shall keep no copies, except to the extent specifically Required by Law(s) made known to Partners by the Data User.<br>
 <br>
 9. THE DATA / DATASETS ARE PROVIDED "AS IS." PARTNERS MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, CONCERNING THE DATA OR DATASETS OR THE RIGHTS GRANTED HEREIN, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, AND THE ABSENCE OF LATENT OR OTHER DEFECTS, WHETHER OR NOT DISCOVERABLE, AND HEREBY DISCLAIMS THE SAME.<br>
 <br>
 10. IN NO EVENT SHALL PARTNERS OR ANY OF PARTNERS' RESPECTIVE TRUSTEES, DIRECTORS, OFFICERS, MEDICAL OR PROFESSIONAL STAFF, EMPLOYEES AND AGENTS BE LIABLE TO THE DATA USER FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES OF ANY KIND ARISING IN ANY WAY OUT OF THIS AGREEMENT OR RIGHTS GRANTED HEREIN, HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, INCLUDING WITHOUT LIMITATION, ECONOMIC DAMAGES OR INJURY TO PROPERTY OR LOST PROFITS, REGARDLESS OF WHETHER PARTNERS SHALL BE ADVISED, SHALL HAVE OTHER REASON TO KNOW, OR IN FACT SHALL KNOW OF THE POSSIBILITY OF THE FOREGOING.<br>
 <br>
-11. Data User agrees not to use the name or logo of Partners or any of its affiliates or any of their respective trustees, directors, officers, staff members, employees, students or agents for any purpose without Partners' prior written approval; provided, however, that Data User will acknowledge Partners as the source of the Data / Datasets in any publication or presentation arising from the Specific Purpose.<br>
+11.	Data User shall indemnify, defend and hold harmless Partners and its affiliates and their respective trustees, directors, officers, medical and professional staff, employees, and agents and their respective successors, heirs and assigns (the Indemnities"), against any liability, damage, loss or expense (including reasonable attorneys' fees and expenses of litigation) incurred by or imposed upon the Indemnitees or any one of them in connection with any claims, suits, actions, demands or judgments arising out of any theory of product liability (including, but not limited to, actions in the form of contract, tort, warranty, or strict liability) concerning any product, tool, technology, process or service made, used, or sold or performed pursuant to any right granted under this Agreement. Data User agrees, at its own expense, to provide attorneys reasonably acceptable to Partners to defend against any actions brought or filed against any party indemnified hereunder with respect to the subject of indemnity contained herein, whether or not such actions are rightfully brought; provided, however, that any Indemnitee shall have the right to retain its own counsel, at the expense of Data User, if representation of such Indemnitee by counsel retained by Data User would be inappropriate because of conflict of interests of such Indemnitee and any other party represented by such counsel. Data User agrees to keep Partners informed of the progress in the defense and disposition of such claim and to consult with Partners prior to any proposed settlement.<br>
 <br>
-12. This Agreement shall become effective upon Partners' release of Data / Datasets to Data User and shall expire upon Data User's completion of the Specific Purpose. Partners may terminate the Agreement and Data User's access to Data / Datasets hereunder at any prior time and for any reason upon written notice to the Data User.<br>
+12.	Data User shall maintain insurance sufficient to meet its obligations under Section 11 of this Agreement.<br>
 <br>
-13. To the extent Data User is permitted under the terms of this Agreement to retain any portion of the Data / Dataset, or any copies thereof, upon the expiration or termination of the Agreement, the Data User's obligations under the Agreement with respect to such Data / Datasets shall survive such expiration or termination for as long as Data User retains the Data / Datasets.<br>
+13.	Data User agrees not to use the name or logo of Partners or any of its affiliates or any of their respective trustees, directors, officers, staff members, employees, students or agents for any purpose without Partners' prior written approval; provided, however, that Data User will acknowledge Partners as the source of the Data / Datasets in any publication or presentation arising from the Specific Purpose.<br>
 <br>
-14. This Agreement may be modified or amended only in a writing signed by duly authorized representatives of both the Data User (where Data User is an organization) and Partners. This Agreement shall be governed by and construed in accordance with the laws of the Commonwealth of Massachusetts. Any claim or action brought under this Agreement shall be brought in the federal or state courts of Massachusetts.<br>
+14.	This Agreement shall become effective upon Partners' release of Data / Datasets to Data User and shall expire upon Data User's completion of the Specific Purpose. Partners may terminate the Agreement and Data User's access to Data / Datasets hereunder at any prior time and for any reason upon written notice to the Data User.<br>
 <br>
-15. All notices required by this Agreement shall be provided to the signatory for each party at the address identified below.<br>
+15.	To the extent Data User is permitted under the terms of this Agreement to retain any portion of the Data / Dataset, or any copies thereof, upon the expiration or termination of the Agreement, the Data User's obligations under the Agreement with respect to such Data / Datasets shall survive such expiration or termination for as long as Data User retains the Data / Datasets.<br>
 <br>
-16. Sections 3 through 11 and Sections 13, 14, and 15 of this Agreement shall survive its expiration or termination.<br>
+16.	This Agreement may be modified or amended only in a writing signed by duly authorized representatives of both the Data User (where Data User is an organization) and Partners. This Agreement shall be governed by and construed in accordance with the laws of the Commonwealth of Massachusetts. Any claim or action brought under this Agreement shall be brought in the federal or state courts of Massachusetts.<br>
+<br>
+17.	All notices required by this Agreement shall be provided to the signatory for each party at the address identified below.<br>
+<br>
+18.	Sections 3 through 13 and Sections 15, 16, and 17 of this Agreement shall survive its expiration or termination.<br>
 <br>
 Agreed to by:<br>
 <br>
@@ -76,9 +74,10 @@ PARTNERS<br>
 Name:<input type="text" class="form-control" name="partners_name"/><br>
 Title: <input type="text" class="form-control" name="partners_title"/><br>
 Address: <input type="text" class="form-control" name="partners_address"/><br>
-Date: <input type="text" class="form-control" name="partners_date"><br>
+Date: <input type="text" class="form-control" name="partners_date"><br><br>
 DATA USER<br>
 <br>
+Signature of Data User (of Data User's Duly Authorized Representative, if an organization)<input type="text" class="form-control" name="data_user_signature"/><br>
 Name:<input type="text" class="form-control" name="data_user_name"/><br>
 Title: <input type="text" class="form-control" name="data_user_title"/><br>
 Address: <input type="text" class="form-control" name="data_user_address"/><br>


### PR DESCRIPTION
Splits the NLP dua form into academic and commercial options. Also adjusts the DataUseAgreementSerializer to not return an agreement_text as an agreement_form.