### PR TITLE
TC-241: Add unit tests to SciAuthZ

### DIFF
--- a/app/authorization/tests.py
+++ b/app/authorization/tests.py
@@ -1,86 +1,289 @@
-from django.urls import reverse
+from datetime import datetime
+from furl import furl
+from pprint import pprint
+from unittest.mock import patch
+
+import json
+
 from rest_framework import status
 from rest_framework.test import APITestCase
+from rest_framework.test import APIClient
+
+from django.conf import settings
 from django.contrib.auth.models import User
+from django.urls import reverse
+
 from authorization.models import UserPermission
 
-from rest_framework.test import APIClient
-from django.conf import settings
-from pprint import pprint
-from furl import furl
+FAKE_ITEM_1 = "Sci.Test"
+FAKE_ITEM_2 = "SciAuthZ.Test"
+FAKE_ITEM_3 = "SciReg.Test"
 
-from datetime import datetime
+USER_EMAIL = "user@example.com"
+OTHER_USER_EMAIL = "user2@example.com"
 
+MANAGER_EMAIL = "manager@example.com"
+MANAGER_PASSWORD = "password"
 
-TEST_USERS = {"user1":
-                  {
-                      "username": "test@test.com"
-                  }}
+class UserPermissionTest(APITestCase):
+    """
+    This class captures various tests related to CRUD actions on the UserPermission model. Authentication
+    in SciAuthZ depends on the presence of a valid JWT in the request header, and from the username field
+    in the JWT the user is determined. However, because getting a valid JWT for unit tests is complicated
+    and might require exposing an Auth0 client secret here or changing our Auth0 configuration drastically,
+    we can mock the username -- pretending it came from a JWT -- and force authentication without a JWT by
+    logging in as a test user.
+    """
 
-
-
-class CreateUserTest(APITestCase):
-
+    managers_permission_1 = None
 
     def setUp(self):
+        """
+        The necessary steps before tests can run.
+        """
 
-        pass
+        # Create a user to force an accepted authentication on all requests. This will not necessarily
+        # always be the user we want to assume is sending the requests, so the individual tests below
+        # will mock the requesting user as necessary.
+        manager_user = User.objects.create_user(MANAGER_EMAIL, email=MANAGER_EMAIL, password=MANAGER_PASSWORD)
+        self.client.force_authenticate(user=manager_user)
 
-    #     # Create a new permission record
-    #     self.user_email = 'test@example.com'
-    #     new_permission = UserPermission.objects.get_or_create(user=self.superuser,
-    #                                                           item="BERSON",
-    #                                                           permission="VIEW",
-    #                                                           date_updated=datetime.now())
+        # MANAGE permissions are always created manually, so create one now.
+        manage_permission = UserPermission.objects.get_or_create(
+            user_email=MANAGER_EMAIL,
+            item=FAKE_ITEM_1,
+            permission="MANAGE"
+        )
 
-    #     new_permission = UserPermission.objects.get_or_create(user=self.superuser,
-    #                                                           item="N2C2",
-    #                                                           permission="VIEW",
-    #                                                           date_updated=datetime.now())
+    @patch('authorization.views.get_email_from_jwt')
+    def test_get_permissions_by_id(self, get_email_from_jwt):
+        """
+        Test GET calls to pull the permission for the given ID. This should always return
+        just one record or none at all.
+        """
 
-    # def test_retrieve_all_permissions(self):
+        # Create a permission for a user for an item that the manager manages.
+        perm = UserPermission.objects.create(
+            user_email=USER_EMAIL,
+            item=FAKE_ITEM_1,
+            permission="VIEW"
+        )
 
-    #     url = "/user_permission/"
-    #     test_user = TEST_USERS["user1"]["username"]
+        f = furl("/user_permission/")
+        f.args["id"] = perm.id
 
-    #     f = furl(url)
-    #     f.args["email"] = test_user
+        # Test that the user with MANAGE permissions can access this item.
+        get_email_from_jwt.return_value = MANAGER_EMAIL
+        response = self.client.get(f.url)
+        self.assertEqual(response.data['count'], 1)
 
-    #     client = APIClient()
-    #     client.login(username=test_user, password='', email=test_user)
+        # Test that the user that this permission belongs to can access their own item.
+        get_email_from_jwt.return_value = USER_EMAIL
+        response = self.client.get(f.url)
+        self.assertEqual(response.data['count'], 1)
 
-    #     response = client.get(f.url)
+        # Test that a user who is neither a manager nor the owner of the record does not get back this item.
+        get_email_from_jwt.return_value = OTHER_USER_EMAIL
+        response = self.client.get(f.url)
+        self.assertEqual(response.data['count'], 0)
 
-    #     # Did we get results back?
-    #     self.assertEqual(response.json()["count"] > 0, True)
+    @patch('authorization.views.get_email_from_jwt')
+    def test_get_permissions_by_item(self, get_email_from_jwt):
+        """
+        Test GET calls to pull permissions for the given item.
+        """
 
-    # def test_single_permission(self):
-    #     url = "/user_permission/"
-    #     test_user = TEST_USERS["user1"]["username"]
+        # Create two sets of permission for the same item that the manager manages.
+        perm1 = UserPermission.objects.create(
+            user_email=USER_EMAIL,
+            item=FAKE_ITEM_1,
+            permission="VIEW"
+        )
+        perm2 = UserPermission.objects.create(
+            user_email=OTHER_USER_EMAIL,
+            item=FAKE_ITEM_2,
+            permission="VIEW"
+        )
 
-    #     f = furl(url)
+        f = furl("/user_permission/")
+        f.args["item"] = FAKE_ITEM_1
 
-    #     f.args["email"] = test_user
-    #     f.args["item"] = "BERSON"
+        # A user with MANAGE permissions should get back two results (his permission and the new one).
+        get_email_from_jwt.return_value = MANAGER_EMAIL
+        response = self.client.get(f.url)
+        self.assertEqual(response.data['count'], 2)
 
-    #     client = APIClient()
-    #     client.login(username=test_user, password='', email=test_user)
+        # Test that the user only sees their own permission.
+        get_email_from_jwt.return_value = USER_EMAIL
+        response = self.client.get(f.url)
+        self.assertEqual(response.data['count'], 1)
 
-    #     response = client.get(f.url)
+        # Test that a request from a different user without this permission does not get anything back.
+        get_email_from_jwt.return_value = OTHER_USER_EMAIL
+        response = self.client.get(f.url)
+        self.assertEqual(response.data['count'], 0)
 
-    #     # Did we get the Berson result back?
-    #     self.assertEqual(response.json()["results"][0]["item"], "BERSON")
+    @patch('authorization.views.get_email_from_jwt')
+    def test_get_permissions_by_user(self, get_email_from_jwt):
+        """
+        Test GET calls to pull the permission for the given user.
+        """
 
-    # def test_has_permission(self):
-    #     # "SciReg.n2c2.profile." + request.user.email
-    #     # VIEW
-    #     url = "/authorization_requests/get_queryset/"
-    #     url = "/user_permission/"
-    #     client = APIClient()
-    #     client.login(username=TEST_USERS["user1"]["username"],password='', email=TEST_USERS["user1"]["username"])
-    #     response = client.get(url + "?email=%s" % TEST_USERS["user1"]["username"])
+        # Create a few permissions for a user.
+        perm1 = UserPermission.objects.create(
+            user_email=USER_EMAIL,
+            item=FAKE_ITEM_1,
+            permission="VIEW"
+        )
+        perm2 = UserPermission.objects.create(
+            user_email=USER_EMAIL,
+            item=FAKE_ITEM_2,
+            permission="VIEW"
+        )
+        perm3 = UserPermission.objects.create(
+            user_email=USER_EMAIL,
+            item=FAKE_ITEM_2,
+            permission="VIEW"
+        )
 
-    #     # pprint(vars(response))
-    #     pprint(response.json()["results"])
+        f = furl("/user_permission/")
+        f.args["email"] = USER_EMAIL
 
-    #     self.assertEqual(1, 1)
+        # The MANAGE user has access to just one of these permissions
+        get_email_from_jwt.return_value = MANAGER_EMAIL
+        response = self.client.get(f.url)
+        self.assertEqual(response.data['count'], 1)
+
+        # The user itself has access to all of their permissions
+        get_email_from_jwt.return_value = USER_EMAIL
+        response = self.client.get(f.url)
+        self.assertEqual(response.data['count'], 3)
+
+        # A random user cannot see any of these permissions
+        get_email_from_jwt.return_value = OTHER_USER_EMAIL
+        response = self.client.get(f.url)
+        self.assertEqual(response.data['count'], 0)
+
+    @patch('authorization.views.get_email_from_jwt')
+    def test_create_view_permission_success(self, get_email_from_jwt):
+        """
+        Test the creation of a VIEW permission. This requires that the request come
+        from someone with MANAGE permissions on the given item.
+        """
+
+        # Mock the user sending the request
+        get_email_from_jwt.return_value = MANAGER_EMAIL
+
+        f = furl("/user_permission/create_item_view_permission_record/")
+
+        # Data for the POST payload
+        data = {
+            "grantee_email": USER_EMAIL,
+            "item": FAKE_ITEM_1
+        }
+
+        response = self.client.post(f.url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @patch('authorization.views.get_email_from_jwt')
+    def test_create_view_permission_denied(self, get_email_from_jwt):
+        """
+        Test an attempt to create a VIEW permission from someone who does not have
+        MANAGE permissions on the given item.
+        """
+
+        # Mock the user sending the request
+        get_email_from_jwt.return_value = USER_EMAIL
+
+        f = furl("/user_permission/create_item_view_permission_record/")
+
+        # Data for the POST payload
+        data = {
+            "grantee_email": USER_EMAIL,
+            "item": FAKE_ITEM_1
+        }
+
+        response = self.client.post(f.url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @patch('authorization.views.get_email_from_jwt')
+    def test_remove_view_permission_success(self, get_email_from_jwt):
+        """
+        Tests the removal of a VIEW permission. This requires that the request come
+        from someone with MANAGE permissions on the given item.
+        """
+
+        # Mock the user sending the request
+        get_email_from_jwt.return_value = MANAGER_EMAIL
+
+        # Create the permission first
+        view_permission = UserPermission.objects.get_or_create(
+            user_email=USER_EMAIL,
+            item=FAKE_ITEM_1,
+            permission="VIEW"
+        )
+
+        f = furl("/user_permission/remove_item_view_permission_record/")
+
+        # Data for the POST payload
+        data = {
+            "grantee_email": USER_EMAIL,
+            "item": FAKE_ITEM_1
+        }
+
+        response = self.client.post(f.url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @patch('authorization.views.get_email_from_jwt')
+    def test_remove_view_permission_denied(self, get_email_from_jwt):
+        """
+        Tests the removal of a VIEW permission from someone who does not have
+        MANAGE permissions on the given item.
+        """
+
+        # Mock the user sending the request
+        get_email_from_jwt.return_value = USER_EMAIL
+
+        # Create the permission first
+        view_permission = UserPermission.objects.get_or_create(
+            user_email=USER_EMAIL,
+            item=FAKE_ITEM_1,
+            permission="VIEW"
+        )
+
+        f = furl("/user_permission/remove_item_view_permission_record/")
+
+        # Data for the POST payload
+        data = {
+            "grantee_email": USER_EMAIL,
+            "item": FAKE_ITEM_1
+        }
+
+        response = self.client.post(f.url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @patch('authorization.views.get_email_from_jwt')
+    def test_create_registration_permission_record(self, get_email_from_jwt):
+        """
+        Tests the creation of a SciReg VIEW permission. The person making the request
+        is giving the grantee permission to view their SciReg profile.
+        """
+
+        # Mock the user sending the request
+        get_email_from_jwt.return_value = USER_EMAIL
+
+        f = furl("/user_permission/create_registration_permission_record/")
+
+        # Data for the POST payload
+        data = {
+            "grantee_email": MANAGER_EMAIL,
+            "item": FAKE_ITEM_1
+        }
+
+        response = self.client.post(f.url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Also required wrapping the get_email_from_request() method from py-auth0-jwt-rest in a new function in order to mock it in the unit tests and faciliate authentication. Lastly, some request.user calls were still being used in the API methods that should have been replaced with the username from the jwt.